### PR TITLE
Respect fullwidth elements in TYPO3 content element preview

### DIFF
--- a/Configuration/TSConfig/GridSystems/custom.tsconfig
+++ b/Configuration/TSConfig/GridSystems/custom.tsconfig
@@ -44,5 +44,9 @@ mod.column_layout {
             itemLabel = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.orders.item_label
             itemLabelDisabled = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.orders.item_label_disabled
         }
+
+        fullwidth {
+            label = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.fullwidth.label
+        }
     }
 }

--- a/Configuration/TSConfig/GridSystems/foundation.tsconfig
+++ b/Configuration/TSConfig/GridSystems/foundation.tsconfig
@@ -44,5 +44,9 @@ mod.column_layout {
             itemLabel = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.orders.item_label
             itemLabelDisabled = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.orders.item_label_disabled
         }
+
+        fullwidth {
+            label = LLL:EXT:column_layout/Resources/Private/Language/locallang_be.xlf:column_layout.fullwidth.label
+        }
     }
 }

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -50,6 +50,10 @@
             <trans-unit id="column_layout.orders.item_label_disabled">
                 <source>auto</source>
             </trans-unit>
+
+            <trans-unit id="column_layout.fullwidth.label">
+                <source>Fullwidth</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Each fullwidth element builds a single row in the frontend. This behaviour should also be used in the backend.