### PR TITLE
Flatten flexform data array

### DIFF
--- a/Classes/Backend/ColumnRenderer.php
+++ b/Classes/Backend/ColumnRenderer.php
@@ -282,8 +282,8 @@ CSS;
 
         // Check all breakpoints for a width value.
         foreach ($checkFieldNames as $fieldName) {
-            if (isset($this->layoutConfiguration['sDEF'][$fieldName]) && $this->layoutConfiguration['sDEF'][$fieldName] > 0) {
-                $width = (int)$this->layoutConfiguration['sDEF'][$fieldName];
+            if (isset($this->layoutConfiguration[$fieldName]) && $this->layoutConfiguration[$fieldName] > 0) {
+                $width = (int)$this->layoutConfiguration[$fieldName];
                 break;
             }
         }
@@ -305,8 +305,8 @@ CSS;
 
         // Check all breakpoints for a width value.
         foreach ($checkFieldNames as $fieldName) {
-            if (isset($this->layoutConfiguration['sOffsets'][$fieldName]) && $this->layoutConfiguration['sOffsets'][$fieldName] > 0) {
-                $offset = (int)$this->layoutConfiguration['sOffsets'][$fieldName];
+            if (isset($this->layoutConfiguration[$fieldName]) && $this->layoutConfiguration[$fieldName] > 0) {
+                $offset = (int)$this->layoutConfiguration[$fieldName];
                 break;
             }
         }
@@ -322,7 +322,7 @@ CSS;
      */
     protected function shouldStartNewRow(): bool
     {
-        return $this->layoutConfiguration['sDEF']['row_behaviour']
+        return $this->layoutConfiguration['row_behaviour']
             || $this->isFullwidthRow()
             || $GLOBALS['TX_COLUMN_LAYOUT']['PageLayoutColumnOffset'][$this->row['colPos']] === 0;
     }
@@ -351,7 +351,7 @@ CSS;
      */
     protected function isFullwidthRow(): bool
     {
-        return (bool)$this->layoutConfiguration['sDEF']['row_fullwidth'];
+        return (bool)$this->layoutConfiguration['row_fullwidth'];
     }
 
     /**

--- a/Classes/DataProcessing/BootstrapColumnClasses.php
+++ b/Classes/DataProcessing/BootstrapColumnClasses.php
@@ -47,34 +47,34 @@ class BootstrapColumnClasses implements DataProcessorInterface
     {
         $classes = [];
 
-        if (!empty($layoutConfiguration['sDEF']['small_width'])) {
-            $classes[] = 'col-' . $layoutConfiguration['sDEF']['small_width'];
+        if (!empty($layoutConfiguration['small_width'])) {
+            $classes[] = 'col-' . $layoutConfiguration['small_width'];
         }
-        if (!empty($layoutConfiguration['sDEF']['medium_width'])) {
-            $classes[] = 'col-md-' . $layoutConfiguration['sDEF']['medium_width'];
+        if (!empty($layoutConfiguration['medium_width'])) {
+            $classes[] = 'col-md-' . $layoutConfiguration['medium_width'];
         }
-        if (!empty($layoutConfiguration['sDEF']['large_width'])) {
-            $classes[] = 'col-lg-' . $layoutConfiguration['sDEF']['large_width'];
-        }
-
-        if (!empty($layoutConfiguration['sOffsets']['small_offset'])) {
-            $classes[] = 'offset-' . $layoutConfiguration['sOffsets']['small_offset'];
-        }
-        if (isset($layoutConfiguration['sOffsets']['medium_offset'])) {
-            $classes[] = 'offset-md-' . $layoutConfiguration['sOffsets']['medium_offset'];
-        }
-        if (isset($layoutConfiguration['sOffsets']['large_offset'])) {
-            $classes[] = 'offset-lg-' . $layoutConfiguration['sOffsets']['large_offset'];
+        if (!empty($layoutConfiguration['large_width'])) {
+            $classes[] = 'col-lg-' . $layoutConfiguration['large_width'];
         }
 
-        if (!empty($layoutConfiguration['sOrders']['small_order'])) {
-            $classes[] = 'order-' . $layoutConfiguration['sOrders']['small_order'];
+        if (!empty($layoutConfiguration['small_offset'])) {
+            $classes[] = 'offset-' . $layoutConfiguration['small_offset'];
         }
-        if (!empty($layoutConfiguration['sOrders']['medium_order'])) {
-            $classes[] = 'order-md-' . $layoutConfiguration['sOrders']['medium_order'];
+        if (isset($layoutConfiguration['medium_offset'])) {
+            $classes[] = 'offset-md-' . $layoutConfiguration['medium_offset'];
         }
-        if (!empty($layoutConfiguration['sOrders']['large_order'])) {
-            $classes[] = 'order-lg-' . $layoutConfiguration['sOrders']['large_order'];
+        if (isset($layoutConfiguration['large_offset'])) {
+            $classes[] = 'offset-lg-' . $layoutConfiguration['large_offset'];
+        }
+
+        if (!empty($layoutConfiguration['small_order'])) {
+            $classes[] = 'order-' . $layoutConfiguration['small_order'];
+        }
+        if (!empty($layoutConfiguration['medium_order'])) {
+            $classes[] = 'order-md-' . $layoutConfiguration['medium_order'];
+        }
+        if (!empty($layoutConfiguration['large_order'])) {
+            $classes[] = 'order-lg-' . $layoutConfiguration['large_order'];
         }
 
         return implode(' ', $classes);

--- a/Classes/DataProcessing/FoundationColumnClasses.php
+++ b/Classes/DataProcessing/FoundationColumnClasses.php
@@ -47,34 +47,34 @@ class FoundationColumnClasses implements DataProcessorInterface
     {
         $classes = [];
 
-        if (!empty($layoutConfiguration['sDEF']['small_width'])) {
-            $classes[] = 'small-' . $layoutConfiguration['sDEF']['small_width'];
+        if (!empty($layoutConfiguration['small_width'])) {
+            $classes[] = 'small-' . $layoutConfiguration['small_width'];
         }
-        if (!empty($layoutConfiguration['sDEF']['medium_width'])) {
-            $classes[] = 'medium-' . $layoutConfiguration['sDEF']['medium_width'];
+        if (!empty($layoutConfiguration['medium_width'])) {
+            $classes[] = 'medium-' . $layoutConfiguration['medium_width'];
         }
-        if (!empty($layoutConfiguration['sDEF']['large_width'])) {
-            $classes[] = 'large-' . $layoutConfiguration['sDEF']['large_width'];
-        }
-
-        if (!empty($layoutConfiguration['sOffsets']['small_offset'])) {
-            $classes[] = 'small-offset-' . $layoutConfiguration['sOffsets']['small_offset'];
-        }
-        if (isset($layoutConfiguration['sOffsets']['medium_offset'])) {
-            $classes[] = 'medium-offset-' . $layoutConfiguration['sOffsets']['medium_offset'];
-        }
-        if (isset($layoutConfiguration['sOffsets']['large_offset'])) {
-            $classes[] = 'large-offset-' . $layoutConfiguration['sOffsets']['large_offset'];
+        if (!empty($layoutConfiguration['large_width'])) {
+            $classes[] = 'large-' . $layoutConfiguration['large_width'];
         }
 
-        if (!empty($layoutConfiguration['sOrders']['small_order'])) {
-            $classes[] = 'small-order-' . $layoutConfiguration['sOrders']['small_order'];
+        if (!empty($layoutConfiguration['small_offset'])) {
+            $classes[] = 'small-offset-' . $layoutConfiguration['small_offset'];
         }
-        if (!empty($layoutConfiguration['sOrders']['medium_order'])) {
-            $classes[] = 'medium-order-' . $layoutConfiguration['sOrders']['medium_order'];
+        if (isset($layoutConfiguration['medium_offset'])) {
+            $classes[] = 'medium-offset-' . $layoutConfiguration['medium_offset'];
         }
-        if (!empty($layoutConfiguration['sOrders']['large_order'])) {
-            $classes[] = 'large-order-' . $layoutConfiguration['sOrders']['large_order'];
+        if (isset($layoutConfiguration['large_offset'])) {
+            $classes[] = 'large-offset-' . $layoutConfiguration['large_offset'];
+        }
+
+        if (!empty($layoutConfiguration['small_order'])) {
+            $classes[] = 'small-order-' . $layoutConfiguration['small_order'];
+        }
+        if (!empty($layoutConfiguration['medium_order'])) {
+            $classes[] = 'medium-order-' . $layoutConfiguration['medium_order'];
+        }
+        if (!empty($layoutConfiguration['large_order'])) {
+            $classes[] = 'large-order-' . $layoutConfiguration['large_order'];
         }
 
         return implode(' ', $classes);

--- a/Classes/Utility/ColumnLayoutUtility.php
+++ b/Classes/Utility/ColumnLayoutUtility.php
@@ -110,7 +110,7 @@ class ColumnLayoutUtility implements SingletonInterface
             }, $sheetValue['lDEF']));
         }
 
-       return $fields;
+        return $fields;
     }
 
     /**

--- a/Classes/Utility/ColumnLayoutUtility.php
+++ b/Classes/Utility/ColumnLayoutUtility.php
@@ -98,19 +98,19 @@ class ColumnLayoutUtility implements SingletonInterface
      */
     public static function hydrateLayoutConfigFlexFormData($flexFormData): array
     {
+        $fields = [];
         $dataStructure = $flexFormData;
         if (is_string($flexFormData)) {
             $dataStructure = GeneralUtility::xml2array($flexFormData);
         }
 
-        // Level: FlexForm Sheets
-        return array_map(function ($sheet) {
-            // Level: FlexForm Sheet Fields
-            return array_map(function ($field) {
-                // Level: FlexForm Field
+        foreach ($dataStructure['data'] as $sheetName => $sheetValue) {
+            $fields = array_merge($fields, array_map(function ($field) {
                 return $field['vDEF'];
-            }, $sheet['lDEF']);
-        }, $dataStructure['data']);
+            }, $sheetValue['lDEF']));
+        }
+
+       return $fields;
     }
 
     /**

--- a/Classes/Utility/ColumnLayoutUtility.php
+++ b/Classes/Utility/ColumnLayoutUtility.php
@@ -104,10 +104,12 @@ class ColumnLayoutUtility implements SingletonInterface
             $dataStructure = GeneralUtility::xml2array($flexFormData);
         }
 
-        foreach ($dataStructure['data'] as $sheetName => $sheetValue) {
-            $fields = array_merge($fields, array_map(function ($field) {
-                return $field['vDEF'];
-            }, $sheetValue['lDEF']));
+        if (is_array($dataStructure)) {
+            foreach ($dataStructure['data'] as $sheetName => $sheetValue) {
+                $fields = array_merge($fields, array_map(function ($field) {
+                    return $field['vDEF'];
+                }, $sheetValue['lDEF']));
+            }
         }
 
         return $fields;


### PR DESCRIPTION
Changes in the flexform might break the functionality of this extension because the extracted data contains the sheets. When a mandatory field is moved to another sheet (like offset or width), the extension is not working any more.

The prevent this, the sheet got removed from the extracted flexform data array. The array now contains only the fields.

It might leads to problems if fields in different sheets contains the same name. But this will be a naming fail.

Resolve #10 